### PR TITLE
create api for splunk communication

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -28,6 +28,11 @@ linters:
         - name: import-shadowing
   exclusions:
     generated: lax
+    presets:
+      - common-false-positives
+      - comments
+      - legacy
+      - std-error-handling
     rules:
       - linters:
           - lll
@@ -36,6 +41,10 @@ linters:
           - dupl
           - lll
         path: internal/*
+      - linters:
+          - goconst
+          - errcheck
+        path: '(.+)_test\.go'
     paths:
       - third_party$
       - builtin$

--- a/internal/splunk/client.go
+++ b/internal/splunk/client.go
@@ -1,0 +1,206 @@
+// Package splunkapi defines a simple api for creating and deleting Splunk
+// HTTP Event Collector (HEC) tokens through Splunk's Admin Config Services
+// interface.
+package splunkapi
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+)
+
+const (
+	acsHostname         string = "https://admin.splunk.com"
+	tokenManagementPath string = "/adminconfig/v2/inputs/http-event-collectors" // #nosec G101 -- not a credential
+
+	missingSplunkError string = "missing Splunk instance name"
+	missingJWTError    string = "missing Splunk authentication token"
+)
+
+// A Client contains the information necessary to connect to Splunk ACS for the
+// specified instance using a JWT for authentication. The zero value of Client
+// does not make any assumptions and contains no information, and the NewClient
+// function should be used to create a working connection.
+type Client struct {
+	jwt    string
+	url    string
+	client http.Client
+}
+
+// The TokenManager interface defines the necessary functions for interacting with Splunk HEC tokens.
+// For our purposes the manager only needs to create and delete tokens.
+type TokenManager interface {
+	CreateToken(context.Context, *HECToken) (*HECToken, error)
+	DeleteToken(context.Context, string) error
+}
+
+// The HECToken struct defines the fields we need for HEC token management.
+// The fields we are concerned with for a HEC token are its name,
+// its value (the auth token itself),
+// and the Splunk indexes the token is able to write to.
+type HECToken struct {
+	Name           string   `json:"name"`
+	DefaultIndex   string   `json:"defaultIndex,omitempty"`
+	AllowedIndexes []string `json:"allowedIndexes,omitempty"`
+	Value          string   `json:"token,omitempty"`
+}
+
+type tokenResponse struct {
+	Data HECToken `json:"http-event-collector"`
+}
+
+type errorResponse struct {
+	Code    string
+	Message string
+}
+
+// NewClient creates a new Splunk Client using the provided instance name and JWT.
+func NewClient(splunkStack, jwt string) (*Client, error) {
+	if splunkStack == "" {
+		return nil, errors.New(missingSplunkError)
+	}
+	if jwt == "" {
+		return nil, errors.New(missingJWTError)
+	}
+
+	fullUrl, err := url.JoinPath(acsHostname, splunkStack, tokenManagementPath)
+	if err != nil {
+		return nil, err
+	}
+	return &Client{
+		jwt:    jwt,
+		url:    fullUrl,
+		client: http.Client{},
+	}, nil
+}
+
+// CreateToken takes a HECToken spec and creates a token on the Splunk instance.
+// The return value for successful token creation is the HECToken with the secret added to the Value field.
+func (c *Client) CreateToken(ctx context.Context, token *HECToken) (*HECToken, error) {
+	// clear Value so Splunk server creates a new token on its own
+	token.Value = ""
+	payload, err := json.Marshal(token)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.url, bytes.NewReader(payload))
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", c.jwt))
+	req.Header.Add("Content-Type", "application/json")
+
+	res, err := c.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+
+	decoder := json.NewDecoder(res.Body)
+	if res.StatusCode >= 400 {
+		response := &errorResponse{}
+		if err := decoder.Decode(response); err != nil {
+			return nil, err
+		}
+		return nil, response
+	}
+
+	// TODO: probably need retries just in case creation takes a while
+	return c.getToken(ctx, token.Name)
+}
+
+// DeleteToken deletes the named token, returning any error from the Splunk server.
+func (c *Client) DeleteToken(ctx context.Context, name string) error {
+	tokenUri, err := url.JoinPath(c.url, name)
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, tokenUri, nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", c.jwt))
+	res, err := c.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusAccepted {
+		decoder := json.NewDecoder(res.Body)
+		response := &errorResponse{}
+		if err := decoder.Decode(response); err != nil {
+			return err
+		}
+		return response
+	}
+	return nil
+}
+
+func (c *Client) getToken(ctx context.Context, name string) (*HECToken, error) {
+	getURL, err := url.JoinPath(c.url, name)
+	if err != nil {
+		return nil, err
+	}
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, getURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	request.Header.Add("Authorization", fmt.Sprintf("Bearer %s", c.jwt))
+	request.Header.Add("Content-Type", "application/json")
+
+	res, err := c.client.Do(request)
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+	decoder := json.NewDecoder(res.Body)
+
+	if res.StatusCode >= 400 {
+		response := &errorResponse{}
+		if err := decoder.Decode(response); err != nil {
+			return nil, err
+		}
+		return nil, response
+	}
+	token := &tokenResponse{}
+	if err := decoder.Decode(token); err != nil {
+		return nil, err
+	}
+	return &token.Data, nil
+}
+
+func (e *errorResponse) Error() string {
+	return fmt.Sprintf("received error response %s: %s", e.Code, e.Message)
+}
+
+func (t *HECToken) UnmarshalJSON(data []byte) error {
+	var temp struct {
+		Spec struct {
+			AllowedIndexes    []string `json:"allowedIndexes,omitempty"`
+			DefaultIndex      string   `json:"defaultIndex,omitempty"`
+			DefaultSource     string   `json:"defaultSource,omitempty"`
+			DefaultSourcetype string   `json:"defaultSourcetype,omitempty"`
+			Disabled          bool     `json:"disabled,omitempty"`
+			Name              string   `json:"name"`
+			UseAck            bool     `json:"useAck,omitempty"`
+		} `json:"spec"`
+		Value string `json:"token"`
+	}
+	err := json.Unmarshal(data, &temp)
+	if err != nil {
+		return err
+	}
+	t.Name = temp.Spec.Name
+	t.DefaultIndex = temp.Spec.DefaultIndex
+	t.AllowedIndexes = temp.Spec.AllowedIndexes
+	t.Value = temp.Value
+	return nil
+}

--- a/internal/splunk/client_test.go
+++ b/internal/splunk/client_test.go
@@ -1,0 +1,277 @@
+//nolint:errcheck,goconst
+package splunkapi
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestCreateClient(t *testing.T) {
+	t.Run("successfully creates", func(t *testing.T) {
+		want := Client{
+			url: "https://admin.splunk.com/mock_splunk/adminconfig/v2/inputs/http-event-collectors",
+			jwt: "foo",
+		}
+
+		got, err := NewClient("mock_splunk", "foo")
+		if err != nil {
+			t.Fatalf("got unexpected error: %s", err)
+		}
+		if got.url != want.url {
+			t.Errorf("expected url %s but got %s", want.url, got.url)
+		}
+		if got.jwt != want.jwt {
+			t.Errorf("expected jwt %s but got %s", want.jwt, got.jwt)
+		}
+	})
+
+	t.Run("returns error if no stack is provided", func(t *testing.T) {
+		_, err := NewClient("", "foo")
+		if err == nil {
+			t.Fatal("expected error but did not get one")
+		}
+		if err.Error() != missingSplunkError {
+			t.Errorf("expected error for missing Splunk name but got %v", err)
+		}
+	})
+
+	t.Run("returns error if no auth token is provided", func(t *testing.T) {
+		_, err := NewClient("mock_splunk", "")
+		if err == nil {
+			t.Fatal("expected error but did not get one")
+		}
+		if err.Error() != missingJWTError {
+			t.Errorf("expected error for missing auth token but got %v", err)
+		}
+	})
+}
+
+func TestCreateToken(t *testing.T) {
+	t.Run("request is formatted properly", func(t *testing.T) {
+		postPath := "/mock_splunk/adminconfig/v2/inputs/http-event-collectors"
+		getPath := "/mock_splunk/adminconfig/v2/inputs/http-event-collectors/bar"
+		wantAuth := "Bearer foo"
+		wantContent := "application/json"
+		wantBody := `{"name":"bar"}`
+		var serverCalls uint
+
+		splunkServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			serverCalls += 1
+			switch r.Method {
+			case http.MethodPost:
+				if r.URL.Path != postPath {
+					t.Errorf("expected POST request to %s but got %s", postPath, r.URL.Path)
+				}
+
+				authHeader := r.Header.Get("Authorization")
+				if authHeader != wantAuth {
+					t.Errorf("expected header Authorization with value '%s' but got '%s'", wantAuth, authHeader)
+				}
+
+				contentType := r.Header.Get("Content-Type")
+				if contentType != wantContent {
+					t.Errorf("expected header Content-Type with value '%s' but got '%s'", wantContent, contentType)
+				}
+
+				body, err := io.ReadAll(r.Body)
+				if err != nil {
+					t.Fatalf("got unexpected error: %s", err)
+				}
+				if string(body) != wantBody {
+					t.Errorf("expected request payload '%s' but got '%s'", wantBody, body)
+				}
+			case http.MethodGet:
+				if r.URL.Path != getPath {
+					t.Errorf("expected GET request to %s but got %s", getPath, r.URL.Path)
+				}
+				authHeader := r.Header.Get("Authorization")
+				if authHeader != wantAuth {
+					t.Errorf("expected header Authorization with value '%s' but got '%s'", wantAuth, authHeader)
+				}
+			}
+		}))
+		defer splunkServer.Close()
+
+		testClient := createTestClient(splunkServer.URL)
+
+		testClient.CreateToken(t.Context(), &HECToken{Name: "bar"})
+		if serverCalls == 0 {
+			t.Errorf("no request made to test server")
+		}
+	})
+
+	t.Run("handles OK response", func(t *testing.T) {
+		tokenName := "bar"
+		splunkServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			createResponse := `{"http-event-collector":{"spec":{"name":"bar"}}}`
+			w.WriteHeader(http.StatusAccepted)
+			io.WriteString(w, createResponse)
+		}))
+		defer splunkServer.Close()
+
+		testClient := createTestClient(splunkServer.URL)
+
+		token := &HECToken{Name: tokenName}
+		token, err := testClient.CreateToken(t.Context(), token)
+		if err != nil {
+			t.Errorf("error creating token: %s", err)
+		}
+
+		// creation response from Splunk is just the token's name
+		if token.Name != tokenName {
+			t.Errorf("expected Name='%s' but got '%s'", tokenName, token.Name)
+		}
+		if token.Value != "" {
+			t.Errorf("expected empty Value but got %s", token.Value)
+		}
+		if token.DefaultIndex != "" {
+			t.Errorf("expected empty DefaultIndex but got %s", token.DefaultIndex)
+		}
+		if token.AllowedIndexes != nil {
+			t.Errorf("expected empty AllowedIndexes but got %v", token.AllowedIndexes)
+		}
+	})
+
+	t.Run("creates with default and allowed indexes", func(t *testing.T) {
+		wantName := "bar"
+		wantIndexes := []string{"audit_index", "other_index"}
+		wantDefault := "audit_index"
+		wantValue := "UUID-VALUE"
+		splunkServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			var createResponse string
+			switch r.Method {
+			case http.MethodPost:
+				createResponse = `{"http-event-collector":{"spec":{"name":"bar"}}}`
+				w.WriteHeader(http.StatusAccepted)
+			case http.MethodGet:
+				createResponse = `{"http-event-collector":{"spec":{"name":"bar","defaultIndex":"audit_index","allowedIndexes":["audit_index","other_index"]},"token":"UUID-VALUE"}}`
+			}
+			io.WriteString(w, createResponse)
+		}))
+		defer splunkServer.Close()
+
+		testClient := createTestClient(splunkServer.URL)
+
+		token := &HECToken{
+			Name:           "bar",
+			AllowedIndexes: []string{"audit_index", "other_index"},
+			DefaultIndex:   "audit_index",
+		}
+		token, err := testClient.CreateToken(t.Context(), token)
+		if err != nil {
+			t.Errorf("error creating token: %s", err)
+		}
+
+		if token.Name != wantName {
+			t.Errorf("expected Name '%s' but got '%s'", wantName, token.Name)
+		}
+		if token.Value != wantValue {
+			t.Errorf("expected Value %s but got %s", wantValue, token.Value)
+		}
+		if token.DefaultIndex != wantDefault {
+			t.Errorf("expected DefaultIndex %s but got %s", wantDefault, token.DefaultIndex)
+		}
+		if !reflect.DeepEqual(wantIndexes, token.AllowedIndexes) {
+			t.Errorf("expected AllowedIndexes %v but got %v", wantIndexes, token.AllowedIndexes)
+		}
+	})
+	t.Run("handles errors", func(t *testing.T) {
+		wantError := "received error response 400-oh-no-it-broke: halt and catch fire"
+		splunkServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			errorJSON := `{"code":"400-oh-no-it-broke","message":"halt and catch fire"}`
+			w.WriteHeader(http.StatusBadRequest)
+			io.WriteString(w, errorJSON)
+		}))
+		defer splunkServer.Close()
+
+		testClient := createTestClient(splunkServer.URL)
+
+		_, err := testClient.CreateToken(t.Context(), &HECToken{Name: "bar"})
+		if err == nil {
+			t.Fatal("expected error but did not receive one")
+		}
+		if err.Error() != wantError {
+			t.Errorf("did not receive expected error message, got %s", err)
+		}
+	})
+}
+
+func TestDeleteToken(t *testing.T) {
+	t.Run("request is formatted properly", func(t *testing.T) {
+		tokenName := "bar"
+		wantMethod := http.MethodDelete
+		wantPath := "/mock_splunk/adminconfig/v2/inputs/http-event-collectors/bar"
+		wantAuth := "Bearer foo"
+		var serverCalls uint
+
+		splunkServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			serverCalls += 1
+			if r.Method == http.MethodDelete {
+				if r.Method != wantMethod {
+					t.Errorf("expected %s request but got %s", wantMethod, r.Method)
+				}
+
+				if r.URL.Path != wantPath {
+					t.Errorf("expected request to %s but got %s", wantPath, r.URL.Path)
+				}
+
+				authHeader := r.Header.Get("Authorization")
+				if authHeader != wantAuth {
+					t.Errorf("expected header Authorization with value '%s' but got '%s'", wantAuth, authHeader)
+				}
+			}
+		}))
+		defer splunkServer.Close()
+
+		testClient := createTestClient(splunkServer.URL)
+		testClient.DeleteToken(t.Context(), tokenName)
+		if serverCalls == 0 {
+			t.Errorf("no request made to test server")
+		}
+	})
+
+	t.Run("handles successful deletion", func(t *testing.T) {
+		splunkServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusAccepted)
+			io.WriteString(w, "")
+		}))
+		defer splunkServer.Close()
+
+		testClient := createTestClient(splunkServer.URL)
+		err := testClient.DeleteToken(t.Context(), "bar")
+		if err != nil {
+			t.Errorf("got unexpected error %s", err)
+		}
+	})
+
+	t.Run("handles deletion errors", func(t *testing.T) {
+		wantError := "received error response 400-oh-no-it-broke: halt and catch fire"
+		splunkServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			errorJSON := `{"code":"400-oh-no-it-broke","message":"halt and catch fire"}`
+			w.WriteHeader(http.StatusBadRequest)
+			io.WriteString(w, errorJSON)
+		}))
+		defer splunkServer.Close()
+
+		testClient := createTestClient(splunkServer.URL)
+
+		err := testClient.DeleteToken(t.Context(), "bar")
+		if err == nil {
+			t.Fatal("expected error but did not receive one")
+		}
+		if err.Error() != wantError {
+			t.Errorf("did not receive expected error message, got %s", err)
+		}
+	})
+}
+
+// helper function to create a Client with the hostname set to the URL of the test server
+func createTestClient(testHostname string) *Client {
+	c, _ := NewClient("mock_splunk", "foo")
+	c.url = strings.Replace(c.url, acsHostname, testHostname, 1)
+	return c
+}


### PR DESCRIPTION
Adds an API interface and unit tests for creating and deleting Splunk HEC tokens, to be used in reconciliation of SplunkToken custom resources.